### PR TITLE
削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user! ,only:[:new, :create, :edit]
-  before_action :item_find, only: [:show, :edit, :update]
+  before_action :item_find, only: [:show, :edit, :update, :destroy]
   before_action :prevent_url, only: [:edit, :update]
 
   def index
@@ -32,6 +32,12 @@ class ItemsController < ApplicationController
     else
       render :edit
     end 
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    end
   end
 
     private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user! ,only:[:new, :create, :edit]
   before_action :item_find, only: [:show, :edit, :update, :destroy]
-  before_action :prevent_url, only: [:edit, :update]
+  before_action :prevent_url, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all.order(created_at: :desc)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user! ,only:[:new, :create, :edit]
+  before_action :authenticate_user! ,only:[:new, :create, :edit, :destroy]
   before_action :item_find, only: [:show, :edit, :update, :destroy]
   before_action :prevent_url, only: [:edit, :update, :destroy]
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
       <% if current_user == @item.user %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
-            <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+            <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
   get 'items', to: 'items#index'
-  resources :items, only: [:new, :create, :index, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
削除機能の実装

# Why
出品した商品を何らかの理由で取り下げたくなった時、
商品削除機能がなければデータがずっと残り続けてしまうため。


ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/f43c5d914b12da5bc9a0e664f95ec6a4